### PR TITLE
Migrate R1CS to linear variable

### DIFF
--- a/include/nil/crypto3/zk/math/linear_combination.hpp
+++ b/include/nil/crypto3/zk/math/linear_combination.hpp
@@ -53,6 +53,9 @@ namespace nil {
                 typedef typename VariableType::value_type field_value_type;
 
             public:
+                typedef typename VariableType::field_type field_type;
+                typedef VariableType variable_type;
+
                 std::size_t index;
                 field_value_type coeff;
 
@@ -117,6 +120,7 @@ namespace nil {
                 constexpr static const bool RotationSupport = false;
 
             public:
+                typedef typename VariableType::field_type field_type;
                 std::vector<linear_term<VariableType>> terms;
 
                 linear_combination() {};

--- a/include/nil/crypto3/zk/math/linear_variable.hpp
+++ b/include/nil/crypto3/zk/math/linear_variable.hpp
@@ -58,6 +58,9 @@ namespace nil {
                 using variable_type = linear_variable<FieldType>;
             public:
 
+                using field_type = FieldType;
+                using value_type = typename FieldType::value_type;
+                using index_type = std::size_t;
                 std::size_t index;
 
                 linear_variable(const std::size_t index = 0) : index(index) {};
@@ -78,7 +81,7 @@ namespace nil {
                 }
 
                 linear_combination<variable_type>
-                    operator-(const linear_combination<FieldType> &other) const {
+                    operator-(const linear_combination<variable_type> &other) const {
                     return (*this) + (-other);
                 }
 

--- a/include/nil/crypto3/zk/snark/arithmetization/constraint_satisfaction_problems/r1cs.hpp
+++ b/include/nil/crypto3/zk/snark/arithmetization/constraint_satisfaction_problems/r1cs.hpp
@@ -37,7 +37,7 @@
 #include <cstdlib>
 #include <vector>
 
-#include <nil/crypto3/zk/snark/arithmetization/variable.hpp>
+#include <nil/crypto3/zk/math/linear_variable.hpp>
 #include <nil/crypto3/zk/math/linear_combination.hpp>
 
 namespace nil {
@@ -57,23 +57,23 @@ namespace nil {
                  *
                  * A R1CS constraint is used to construct a R1CS constraint system (see below).
                  */
-                template<typename FieldType>
+                template<typename FieldType, typename VariableType = math::linear_variable<FieldType>>
                 struct r1cs_constraint {
                     typedef FieldType field_type;
 
-                    linear_combination<FieldType> a, b, c;
+                    math::linear_combination<VariableType> a, b, c;
 
                     r1cs_constraint() {};
-                    r1cs_constraint(const linear_combination<FieldType> &a,
-                                    const linear_combination<FieldType> &b,
-                                    const linear_combination<FieldType> &c) :
+                    r1cs_constraint(const math::linear_combination<VariableType> &a,
+                                    const math::linear_combination<VariableType> &b,
+                                    const math::linear_combination<VariableType> &c) :
                         a(a),
                         b(b), c(c) {
                     }
 
-                    r1cs_constraint(const std::initializer_list<linear_combination<FieldType>> &A,
-                                    const std::initializer_list<linear_combination<FieldType>> &B,
-                                    const std::initializer_list<linear_combination<FieldType>> &C) {
+                    r1cs_constraint(const std::initializer_list<math::linear_combination<VariableType>> &A,
+                                    const std::initializer_list<math::linear_combination<VariableType>> &B,
+                                    const std::initializer_list<math::linear_combination<VariableType>> &C) {
                         for (auto lc_A : A) {
                             a.terms.insert(a.terms.end(), lc_A.terms.begin(), lc_A.terms.end());
                         }


### PR DESCRIPTION
Note, the typedefs are for zk-marshalling
Related: NilFoundation/crypto3-zk-marshalling#11