### PR TITLE
Added support for all evalutation domains to mpc crs generation

### DIFF
--- a/include/nil/crypto3/zk/commitments/detail/polynomial/r1cs_gg_ppzksnark_mpc/crs_operatios.hpp
+++ b/include/nil/crypto3/zk/commitments/detail/polynomial/r1cs_gg_ppzksnark_mpc/crs_operatios.hpp
@@ -36,7 +36,7 @@ namespace nil {
                         typename proving_scheme_type::constraint_system_type r1cs_copy(constraint_system);
                         r1cs_copy.swap_AB_if_beneficial();
 
-                        qap_instance<scalar_field_type> qap = reductions::r1cs_to_qap<scalar_field_type, reductions::domain_mode::basic_only>::instance_map(r1cs_copy);
+                        qap_instance<scalar_field_type> qap = reductions::r1cs_to_qap<scalar_field_type>::instance_map(r1cs_copy);
 
                         BOOST_ASSERT_MSG(powers_of_tau_result.coeffs_g1.size() == qap.domain->m, "powers_of_tau_result size does not match the constraint system");
                         BOOST_ASSERT_MSG(powers_of_tau_result.coeffs_g2.size() == qap.domain->m, "powers_of_tau_result size does not match the constraint system");

--- a/include/nil/crypto3/zk/snark/reductions/r1cs_to_qap.hpp
+++ b/include/nil/crypto3/zk/snark/reductions/r1cs_to_qap.hpp
@@ -61,12 +61,7 @@ namespace nil {
         namespace zk {
             namespace snark {
                 namespace reductions {
-                    enum class domain_mode {
-                        minimal,
-                        basic_only
-                    };
-
-                    template<typename FieldType, domain_mode OnlyBasicDomain = domain_mode::minimal>
+                    template<typename FieldType>
                     struct r1cs_to_qap {
                         typedef FieldType field_type;
 
@@ -84,8 +79,7 @@ namespace nil {
                          */
                         static qap_instance<FieldType> instance_map(const r1cs_constraint_system<FieldType> &cs) {
 
-                            const std::shared_ptr<math::evaluation_domain<FieldType>> domain = OnlyBasicDomain == domain_mode::basic_only ?
-                                math::make_evaluation_domain<FieldType>(math::detail::power_of_two(cs.num_constraints() + cs.num_inputs() + 1)) :
+                            const std::shared_ptr<math::evaluation_domain<FieldType>> domain =
                                 math::make_evaluation_domain<FieldType>(cs.num_constraints() + cs.num_inputs() + 1);
 
                             std::vector<std::map<std::size_t, typename FieldType::value_type>> A_in_Lagrange_basis(
@@ -144,8 +138,7 @@ namespace nil {
                         static qap_instance_evaluation<FieldType>
                             instance_map_with_evaluation(const r1cs_constraint_system<FieldType> &cs,
                                                          const typename FieldType::value_type &t) {
-                            const std::shared_ptr<math::evaluation_domain<FieldType>> domain = OnlyBasicDomain == domain_mode::basic_only ?
-                                math::make_evaluation_domain<FieldType>(math::detail::power_of_two(cs.num_constraints() + cs.num_inputs() + 1)) :
+                            const std::shared_ptr<math::evaluation_domain<FieldType>> domain = 
                                 math::make_evaluation_domain<FieldType>(cs.num_constraints() + cs.num_inputs() + 1);
 
                             std::vector<typename FieldType::value_type> At, Bt, Ct, Ht;
@@ -233,8 +226,7 @@ namespace nil {
                             /* sanity check */
                             assert(cs.is_satisfied(primary_input, auxiliary_input));
 
-                            const std::shared_ptr<math::evaluation_domain<FieldType>> domain = OnlyBasicDomain == domain_mode::basic_only ?
-                                math::make_evaluation_domain<FieldType>(math::detail::power_of_two(cs.num_constraints() + cs.num_inputs() + 1)) :
+                            const std::shared_ptr<math::evaluation_domain<FieldType>> domain =
                                 math::make_evaluation_domain<FieldType>(cs.num_constraints() + cs.num_inputs() + 1);
 
                             r1cs_variable_assignment<FieldType> full_variable_assignment = primary_input;

--- a/include/nil/crypto3/zk/snark/systems/ppzksnark/r1cs_gg_ppzksnark/generator.hpp
+++ b/include/nil/crypto3/zk/snark/systems/ppzksnark/r1cs_gg_ppzksnark/generator.hpp
@@ -46,7 +46,7 @@ namespace nil {
     namespace crypto3 {
         namespace zk {
             namespace snark {
-                template<typename CurveType, proving_mode Mode = proving_mode::basic, reductions::domain_mode DomainMode = reductions::domain_mode::minimal, typename = void>
+                template<typename CurveType, proving_mode Mode = proving_mode::basic, typename = void>
                 class r1cs_gg_ppzksnark_generator;
 
                 /**
@@ -55,8 +55,8 @@ namespace nil {
                  * Given a R1CS constraint system CS, this algorithm produces proving and verification keys for
                  * CS.
                  */
-                template<typename CurveType, reductions::domain_mode DomainMode>
-                class r1cs_gg_ppzksnark_generator<CurveType, proving_mode::basic, DomainMode> {
+                template<typename CurveType>
+                class r1cs_gg_ppzksnark_generator<CurveType, proving_mode::basic> {
 
                     typedef detail::r1cs_gg_ppzksnark_basic_policy<CurveType, proving_mode::basic> policy_type;
 
@@ -105,7 +105,7 @@ namespace nil {
 
                         /* A quadratic arithmetic program evaluated at t. */
                         qap_instance_evaluation<scalar_field_type> qap =
-                            reductions::r1cs_to_qap<scalar_field_type, DomainMode>::instance_map_with_evaluation(r1cs_copy, t);
+                            reductions::r1cs_to_qap<scalar_field_type>::instance_map_with_evaluation(r1cs_copy, t);
 
                         std::size_t non_zero_At = 0;
                         std::size_t non_zero_Bt = 0;
@@ -257,7 +257,7 @@ namespace nil {
 
                         /* A quadratic arithmetic program evaluated at t. */
                         qap_instance_evaluation<scalar_field_type> qap =
-                            reductions::r1cs_to_qap<scalar_field_type, DomainMode>::instance_map_with_evaluation(r1cs_copy, t);
+                            reductions::r1cs_to_qap<scalar_field_type>::instance_map_with_evaluation(r1cs_copy, t);
 
                         std::size_t non_zero_At = 0;
                         std::size_t non_zero_Bt = 0;

--- a/include/nil/crypto3/zk/snark/systems/ppzksnark/r1cs_gg_ppzksnark/prover.hpp
+++ b/include/nil/crypto3/zk/snark/systems/ppzksnark/r1cs_gg_ppzksnark/prover.hpp
@@ -44,7 +44,7 @@ namespace nil {
     namespace crypto3 {
         namespace zk {
             namespace snark {
-                template<typename CurveType, proving_mode Mode = proving_mode::basic, reductions::domain_mode DomainMode = reductions::domain_mode::minimal>
+                template<typename CurveType, proving_mode Mode = proving_mode::basic>
                 class r1cs_gg_ppzksnark_prover;
 
                 /**
@@ -55,8 +55,8 @@ namespace nil {
                  *               ``there exists Y such that CS(X,Y)=0''.
                  * Above, CS is the R1CS constraint system that was given as input to the generator algorithm.
                  */
-                template<typename CurveType, reductions::domain_mode DomainMode>
-                class r1cs_gg_ppzksnark_prover<CurveType, proving_mode::basic, DomainMode> {
+                template<typename CurveType>
+                class r1cs_gg_ppzksnark_prover<CurveType, proving_mode::basic> {
                     typedef detail::r1cs_gg_ppzksnark_basic_policy<CurveType, proving_mode::basic> policy_type;
 
                     typedef typename CurveType::scalar_field_type scalar_field_type;
@@ -77,7 +77,7 @@ namespace nil {
                         BOOST_ASSERT(proving_key.constraint_system.is_satisfied(primary_input, auxiliary_input));
 
                         const qap_witness<scalar_field_type> qap_wit =
-                            reductions::r1cs_to_qap<scalar_field_type, DomainMode>::witness_map(
+                            reductions::r1cs_to_qap<scalar_field_type>::witness_map(
                                 proving_key.constraint_system, primary_input, auxiliary_input,
                                 scalar_field_type::value_type::zero(), scalar_field_type::value_type::zero(),
                                 scalar_field_type::value_type::zero());

--- a/test/commitment/powers_of_tau.cpp
+++ b/test/commitment/powers_of_tau.cpp
@@ -58,6 +58,12 @@ BOOST_AUTO_TEST_CASE(powers_of_tau_result_basic_test) {
         BOOST_CHECK_MESSAGE(result.beta_coeffs_g1[i] == g1_generator * (sk.beta * u[i]), std::string("i=") + std::to_string(i));
     }
 
+    BOOST_CHECK_EQUAL(result.h.size(), domain->m-1);
+    auto Zt = domain->compute_vanishing_polynomial(sk.tau);
+    for(std::size_t i = 0; i<domain->m-1; ++i) {
+        BOOST_CHECK_MESSAGE(result.h[i] == g1_generator * (sk.tau.pow(i) * Zt), std::string("i=") + std::to_string(i));
+    }
+
     auto result_16 = scheme_type::result_type::from_accumulator(acc2, 16);
     auto domain_16 = nil::crypto3::math::make_evaluation_domain<scalar_field_type>(16);
     auto u_16 = domain_16->evaluate_all_lagrange_polynomials(sk.tau);
@@ -78,6 +84,40 @@ BOOST_AUTO_TEST_CASE(powers_of_tau_result_basic_test) {
         BOOST_CHECK_MESSAGE(result_16.coeffs_g2[i] == g2_generator * u_16[i], std::string("i=") + std::to_string(i));
         BOOST_CHECK_MESSAGE(result_16.alpha_coeffs_g1[i] == g1_generator *(sk.alpha * u_16[i]), std::string("i=") + std::to_string(i));
         BOOST_CHECK_MESSAGE(result_16.beta_coeffs_g1[i] == g1_generator * (sk.beta * u_16[i]), std::string("i=") + std::to_string(i));
+    }
+
+    BOOST_CHECK_EQUAL(result_16.h.size(), domain_16->m-1);
+    auto Zt_16 = domain_16->compute_vanishing_polynomial(sk.tau);
+    for(std::size_t i = 0; i<domain_16->m-1; ++i) {
+        BOOST_CHECK_MESSAGE(result_16.h[i] == g1_generator * (sk.tau.pow(i) * Zt_16), std::string("i=") + std::to_string(i));
+    }
+
+    auto result_24 = scheme_type::result_type::from_accumulator(acc2, 24);
+    auto domain_24 = nil::crypto3::math::make_evaluation_domain<scalar_field_type>(24);
+    auto u_24 = domain_24->evaluate_all_lagrange_polynomials(sk.tau);
+    
+    BOOST_CHECK_EQUAL(u_24.size(), 24);
+
+    BOOST_CHECK(result_24.alpha_g1 == g1_generator * sk.alpha);
+    BOOST_CHECK(result_24.beta_g1 == g1_generator * sk.beta);
+    BOOST_CHECK(result_24.beta_g2 == g2_generator * sk.beta);
+    
+    BOOST_CHECK_EQUAL(result_24.coeffs_g1.size(), 24);
+    BOOST_CHECK_EQUAL(result_24.coeffs_g2.size(), 24);
+    BOOST_CHECK_EQUAL(result_24.alpha_coeffs_g1.size(), 24);
+    BOOST_CHECK_EQUAL(result_24.beta_coeffs_g1.size(), 24);
+
+    for(std::size_t i = 0; i < domain_24->m; ++i) {
+        BOOST_CHECK_MESSAGE(result_24.coeffs_g1[i] == g1_generator * u_24[i], std::string("i=") + std::to_string(i));
+        BOOST_CHECK_MESSAGE(result_24.coeffs_g2[i] == g2_generator * u_24[i], std::string("i=") + std::to_string(i));
+        BOOST_CHECK_MESSAGE(result_24.alpha_coeffs_g1[i] == g1_generator *(sk.alpha * u_24[i]), std::string("i=") + std::to_string(i));
+        BOOST_CHECK_MESSAGE(result_24.beta_coeffs_g1[i] == g1_generator * (sk.beta * u_24[i]), std::string("i=") + std::to_string(i));
+    }
+
+    BOOST_CHECK_EQUAL(result_24.h.size(), domain_24->m-1);
+    auto Zt_24 = domain_24->compute_vanishing_polynomial(sk.tau);
+    for(std::size_t i = 0; i<domain_24->m-1; ++i) {
+        BOOST_CHECK_MESSAGE(result_24.h[i] == g1_generator * (sk.tau.pow(i) * Zt_24), std::string("i=") + std::to_string(i));
     }
 }
 


### PR DESCRIPTION
Initially the Groth16 CRS MPC protocols only supported basic radix 2m domains.
This PR adds support for all exisiting evalutation domain implementations, thus allowing for more flexible domain choice and faster proving time.

Depends on:
* https://github.com/NilFoundation/crypto3-math/pull/19
* https://github.com/NilFoundation/crypto3-math/pull/20