### PR TITLE
121 lpc fri tests

### DIFF
--- a/include/nil/crypto3/zk/commitments/detail/polynomial/basic_fri.hpp
+++ b/include/nil/crypto3/zk/commitments/detail/polynomial/basic_fri.hpp
@@ -82,11 +82,8 @@ namespace nil {
                         typedef std::array<typename field_type::value_type, m> polynomial_value_type;
                         typedef std::vector<polynomial_value_type> polynomial_values_type;
 
-                        // For initial proof only
-                        typedef typename std::vector<polynomial_values_type> polynomials_values_type;
-
-                        // For other rounds
-                        typedef std::vector<polynomial_values_type> rounds_polynomial_values_type;
+                        // For initial proof only, size of all values are similar
+                        typedef std::vector<polynomial_values_type> polynomials_values_type;
 
                         typedef typename containers::merkle_tree<MerkleTreeHashType, 2> merkle_tree_type;
                         typedef typename containers::merkle_proof<MerkleTreeHashType, 2> merkle_proof_type;
@@ -103,7 +100,8 @@ namespace nil {
 
                         struct params_type {
                             bool operator==(const params_type &rhs) const {
-                                return r == rhs.r && max_degree == rhs.max_degree && D == rhs.D;
+                                return r == rhs.r && max_degree == rhs.max_degree && D == rhs.D && 
+                                    batches_num == rhs.batches_num;
                             }
                             bool operator!=(const params_type &rhs) const {
                                 return !(rhs == *this);
@@ -123,8 +121,8 @@ namespace nil {
 
                             params_type() {};
 
-                            std::size_t r;
                             std::size_t batches_num;
+                            std::size_t r;
                             std::size_t max_degree;
                             std::vector<std::shared_ptr<math::evaluation_domain<FieldType>>> D;
                             std::vector<std::size_t> step_list;
@@ -139,8 +137,9 @@ namespace nil {
                                 return !(rhs == *this);
                             }
 
-                            merkle_proof_type p;                          // for proof(values[i], T_{i-})
-                            std::vector<std::array<typename field_type::value_type, m>> y;
+                            polynomial_values_type y;                   // Values for the next round.
+                                                                        // For the last round it's final_polynomial's values
+                            merkle_proof_type p;                        // Merkle proof(values[i-1], T_i)
                         };
 
                         struct initial_proof_type{

--- a/include/nil/crypto3/zk/commitments/detail/polynomial/basic_fri.hpp
+++ b/include/nil/crypto3/zk/commitments/detail/polynomial/basic_fri.hpp
@@ -725,10 +725,8 @@ namespace nil {
                     std::size_t t = 0;
                     for(std::size_t i = 0; i < fri_params.step_list.size(); i++){
                         transcript(proof.fri_roots[i]);
-//                        std::cout << "fri_roots[" << i << "]="<< std::hex << proof.fri_roots[i] << std::dec << std::endl;
                         for(std::size_t step_i = 0; step_i < fri_params.step_list[i]; step_i++, t++){
                             auto alpha = transcript.template challenge<typename FRI::field_type>();
-//                            std::cout << "alpha=" << alpha.data << std::endl;
                             alphas.push_back(alpha);
                         }
                     }
@@ -739,7 +737,6 @@ namespace nil {
                         std::size_t domain_size = fri_params.D[0]->size();
                         std::size_t coset_size = 1 << fri_params.step_list[0];
                         std::uint64_t x_index = (transcript.template int_challenge<std::uint64_t>()) % domain_size;
-//                        std::cout << "x_index=" << x_index << std::endl;
                         typename FRI::field_type::value_type x = fri_params.D[0]->get_domain_element(x_index);
 
                         std::vector<std::array<typename FRI::field_type::value_type, FRI::m>> s;
@@ -760,13 +757,9 @@ namespace nil {
 
                             for (std::size_t i = 0; i < query_proof.initial_proof[k].values.size(); i++) {
                                 for (auto [idx, pair_idx] : correct_order_idx) {
-//                                    std::cout << "[" << k << "][" << i << "][" << idx << "][" << pair_idx << "]=" 
-//                                        << query_proof.initial_proof[k].values[i][idx][pair_idx].data << std::endl;
                                     typename FRI::field_element_type leaf_val0(
                                         query_proof.initial_proof[k].values[i][idx][pair_idx]
                                     );
-//                                    std::cout << "[" << k << "][" << i << "][" << idx << "][" << 1-pair_idx << "]=" 
-//                                        << query_proof.initial_proof[k].values[i][idx][1-pair_idx].data << std::endl;
                                     leaf_val0.write(write_iter, FRI::field_element_type::length());
                                     typename FRI::field_element_type leaf_val1(
                                         query_proof.initial_proof[k].values[i][idx][1-pair_idx]
@@ -789,7 +782,6 @@ namespace nil {
                             y[j][1] = FRI::field_type::value_type::zero();
                         }
                         for( size_t eval_ind = 0; eval_ind < evals_num; eval_ind++){
-//                            std::cout << "*******************eval_ind = " << eval_ind << "*******************" << std::endl;
                             std::size_t ind = 0;
                             for( size_t j = 0; j < coset_size / FRI::m; j++ ){
                                 combined_eval_values[j][0] = FRI::field_type::value_type::zero();
@@ -801,39 +793,17 @@ namespace nil {
                                         combined_eval_values[j][0] *= theta;
                                         combined_eval_values[j][1] *= theta;
                                         if( evals_map[ind] == eval_ind ){
-//                                            std::cout << "query_proof.initial_proof[" << k << "].values[" << i << "]["<< j<< "][0]" << std::hex << query_proof.initial_proof[k].values[i][j][0].data << std::dec << std::endl;
-//                                            std::cout << "query_proof.initial_proof[" << k << "].values[" << i << "]["<< j<< "][1]" << std::hex << query_proof.initial_proof[k].values[i][j][1].data << std::dec << std::endl;
                                             combined_eval_values[j][0] += query_proof.initial_proof[k].values[i][j][0];
                                             combined_eval_values[j][1] += query_proof.initial_proof[k].values[i][j][1];
                                         }
                                     }
                                 }
                             }
-                            //std::cout << "combined_U:" << std::endl;
-                            //for( size_t j = 0; j < combined_U[eval_ind].size(); j++){
-                            //    std::cout << "\t" << combined_U[eval_ind][j].data << std::endl;
-                            //}
-                            //std::cout << "denominator:" << std::endl;
-                            //for( size_t j = 0; j < denominators[eval_ind].size(); j++){
-                            //    std::cout << "\t" << denominators[eval_ind][j].data << std::endl;
-                            //}
                             for( size_t j = 0; j < coset_size / FRI::m; j++ ){
-                                //std::cout << "s["<<j<<"][0] = " << s[j][0].data << std::endl;
-                                //std::cout << "s["<<j<<"][1] = " << s[j][1].data << std::endl;
-                                //std::cout << "before combined_eval_values["<<j<<"][0] = " << combined_eval_values[j][0].data << std::endl;
-                                //std::cout << "before combined_eval_values["<<j<<"][1] = " << combined_eval_values[j][1].data << std::endl;
                                 combined_eval_values[j][0] -= combined_U[eval_ind].evaluate(s[j][0]);
                                 combined_eval_values[j][1] -= combined_U[eval_ind].evaluate(s[j][1]);
-                                //std::cout << "combined_U" << std::endl;
-                                //std::cout <<  "\t" << combined_U[eval_ind].evaluate(s[j][0]).data << std::endl;
-                                //std::cout <<  "\t" << combined_U[eval_ind].evaluate(s[j][1]).data << std::endl;
-                                //std::cout << "denominator" << std::endl;
-                                //std::cout <<  "\t" << denominators[eval_ind].evaluate(s[j][0]).data << std::endl;
-                                //std::cout <<  "\t" << denominators[eval_ind].evaluate(s[j][1]).data << std::endl;
                                 combined_eval_values[j][0] /= denominators[eval_ind].evaluate(s[j][0]);
                                 combined_eval_values[j][1] /= denominators[eval_ind].evaluate(s[j][1]);
-                                //std::cout << "after combined_eval_values["<<j<<"][0] = " << combined_eval_values[j][0].data << std::endl;
-                                //std::cout << "after combined_eval_values["<<j<<"][1] = " << combined_eval_values[j][1].data << std::endl;
 
                                 y[j][0] += combined_eval_values[j][0]; 
                                 y[j][1] += combined_eval_values[j][1]; 
@@ -844,9 +814,7 @@ namespace nil {
                         std::size_t t = 0;
                         typename FRI::polynomial_values_type y_next;
                         for (std::size_t i = 0; i < fri_params.step_list.size(); i++) {
-//                            std::cout << "Round " << i << std::endl;
                             coset_size = 1 << fri_params.step_list[i];
-                            // check merkle proof p, polynomails' values y are already prepared
                             if(query_proof.round_proofs[i].p.root() !=  proof.fri_roots[i] ) return false;
 
                             std::tie(s, s_indices) = calculate_s<FRI>(x, x_index, fri_params.step_list[i], fri_params.D[t]);
@@ -854,24 +822,18 @@ namespace nil {
                             auto write_iter = leaf_data.begin();
                             auto correct_order_idx =
                                 get_correct_order<FRI>(x_index, domain_size, fri_params.step_list[i], s_indices);
-  //                          std::cout << "indices " << x_index << "," << get_folded_index<FRI>(x_index, domain_size, fri_params.step_list[i]) << std::endl;
                             for (auto [idx, pair_idx] : correct_order_idx) {
- //                               std::cout << "y[" << idx << "][" << pair_idx << "] = " << y[idx][pair_idx].data << std::endl;
                                 typename FRI::field_element_type leaf_val0(y[idx][pair_idx]);
                                 leaf_val0.write(write_iter, FRI::field_element_type::length());
-//                                std::cout << "y[" << idx << "][" << 1-pair_idx << "] = " << y[idx][1 - pair_idx].data << std::endl;
                                 typename FRI::field_element_type leaf_val1(y[idx][1 - pair_idx]);
                                 leaf_val1.write(write_iter, FRI::field_element_type::length());
                             }
                             if ( !query_proof.round_proofs[i].p.validate(leaf_data)) {
-//                                std::cout << "Merkle proof is not correct" << std::endl;
                                 return false;
-                            } else {
                             }
 
                             // colinear check
                             for( std::size_t step_i = 0; step_i < fri_params.step_list[i] - 1; step_i++, t++ ){
-//                                std:: cout << "Step" << t  << std::endl;
                                 y_next.resize( y.size() / FRI::m );
 
                                 domain_size = fri_params.D[t]->size();
@@ -886,7 +848,6 @@ namespace nil {
                                     math::polynomial<typename FRI::field_type::value_type> interpolant_l =
                                         math::lagrange_interpolation(interpolation_points_l);
                                     y_next[y_ind][0] = interpolant_l.evaluate(alphas[t]);
-//                                    std::cout << "y_next[" << y_ind << "][0] = " << y_next[y_ind][0].data << std::endl;
 
                                     std::vector<std::pair<typename FRI::field_type::value_type,typename FRI::field_type::value_type>> interpolation_points_r {
                                         std::make_pair(s[2 * y_ind + 1][0], y[2 * y_ind + 1][0]),
@@ -895,7 +856,6 @@ namespace nil {
                                     math::polynomial<typename FRI::field_type::value_type> interpolant_r =
                                         math::lagrange_interpolation(interpolation_points_r);
                                     y_next[y_ind][1] = interpolant_r.evaluate(alphas[t]);
-//                                    std::cout << "y_next[" << y_ind << "][1] = " << y_next[y_ind][1].data << std::endl;
                                 }
                                 x = x*x;
                                 y = y_next;

--- a/include/nil/crypto3/zk/commitments/polynomial/fri.hpp
+++ b/include/nil/crypto3/zk/commitments/polynomial/fri.hpp
@@ -85,7 +85,6 @@ namespace nil {
                     using transcript_hash_type = typename basic_fri::transcript_hash_type;
                     using merkle_tree_type = typename basic_fri::merkle_tree_type;
                     using merkle_proof_type = typename basic_fri::merkle_proof_type;
-                    using round_proof_type = typename basic_fri::round_proof_type;
                     using proof_type = typename basic_fri::proof_type;
                     using params_type = typename basic_fri::params_type;
                     using transcript_type = typename basic_fri::transcript_type;
@@ -95,8 +94,8 @@ namespace nil {
                 };
             }    // namespace commitments
 
-            // Proof and verify for one polynomial
             namespace algorithms {
+                // Proof and verify for one polynomial
                 template<typename FRI,
                         typename PolynomialType,
                         typename std::enable_if<std::is_base_of<commitments::fri<typename FRI::field_type,

--- a/include/nil/crypto3/zk/commitments/polynomial/lpc.hpp
+++ b/include/nil/crypto3/zk/commitments/polynomial/lpc.hpp
@@ -157,8 +157,6 @@ namespace nil {
                 ) {
                     for(std::size_t i = 0; i < LPC::basic_fri::batches_num; i++) {
                         transcript(commit<typename LPC::basic_fri>(precommitments[i]));
-//                        std::cout << "commitment[" << i << "] = " << std::hex 
-//                            << commit<typename LPC::basic_fri>(precommitments[i]) << std::dec << std::endl;
                     }
                     typename LPC::field_type::value_type theta = transcript.template challenge<typename LPC::field_type>();
                     math::polynomial<typename LPC::field_type::value_type> combined_Q;
@@ -337,7 +335,6 @@ namespace nil {
                     typename std::vector<math::polynomial<typename LPC::field_type::value_type>> denominators;
                     typename LPC::field_type::value_type theta = transcript.template challenge<typename LPC::field_type>();
 
-//                    std::cout << "theta=" << theta.data << std::endl;
                     std::size_t batch_size = 0;
                     for( std::size_t k = 0; k < LPC::basic_fri::batches_num; k++){
                         BOOST_ASSERT( evaluation_points[k].size() == proof.z[k].size() || evaluation_points[k].size() == 1);

--- a/include/nil/crypto3/zk/commitments/polynomial/lpc.hpp
+++ b/include/nil/crypto3/zk/commitments/polynomial/lpc.hpp
@@ -155,7 +155,12 @@ namespace nil {
                     const typename LPC::basic_fri::params_type &fri_params,
                     typename LPC::basic_fri::transcript_type &transcript = typename LPC::basic_fri::transcript_type()
                 ) {
-                    typename LPC::field_type::value_type combined_alpha = transcript.template challenge<typename LPC::field_type>();
+                    for(std::size_t i = 0; i < LPC::basic_fri::batches_num; i++) {
+                        transcript(commit<typename LPC::basic_fri>(precommitments[i]));
+//                        std::cout << "commitment[" << i << "] = " << std::hex 
+//                            << commit<typename LPC::basic_fri>(precommitments[i]) << std::dec << std::endl;
+                    }
+                    typename LPC::field_type::value_type theta = transcript.template challenge<typename LPC::field_type>();
                     math::polynomial<typename LPC::field_type::value_type> combined_Q;
                     std::array<typename LPC::proof_type::z_type, LPC::basic_fri::batches_num> z;
 
@@ -186,7 +191,7 @@ namespace nil {
                             math::polynomial<typename LPC::field_type::value_type> U = math::lagrange_interpolation(U_interpolation_points);
 
                             Q = g[k][polynom_index] - U;
-                            combined_U = combined_U * combined_alpha;
+                            combined_U = combined_U * theta;
                             combined_U = combined_U + U;
 
                             math::polynomial<typename LPC::field_type::value_type> denominator_polynom = {1};
@@ -200,7 +205,7 @@ namespace nil {
                             if (k == 0 && polynom_index == 0) {
                                 combined_Q = Q;
                             } else {
-                                combined_Q = combined_Q * combined_alpha + Q;
+                                combined_Q = combined_Q * theta + Q;
                             }
                         }
                     }
@@ -231,8 +236,12 @@ namespace nil {
                     const typename LPC::basic_fri::params_type &fri_params,
                     typename LPC::basic_fri::transcript_type &transcript = typename LPC::basic_fri::transcript_type()
                 ) {
+                    for(std::size_t i = 0; i < LPC::basic_fri::batches_num; i++) {
+                        transcript(commit<typename LPC::basic_fri>(precommitments[i]));
+                    }
+                    
                     // Prepare z-s and combined_Q;
-                    typename LPC::field_type::value_type combined_alpha = transcript.template challenge<typename LPC::field_type>();
+                    typename LPC::field_type::value_type theta = transcript.template challenge<typename LPC::field_type>();
                     math::polynomial_dfs<typename LPC::field_type::value_type> combined_Q_dfs(
                         0, fri_params.D[0]->size(), 
                         LPC::field_type::value_type::zero()
@@ -284,7 +293,7 @@ namespace nil {
                             if (k == 0 && polynom_index == 0) {
                                 combined_Q_dfs = Q_dfs;
                             } else {
-                                combined_Q_dfs *= combined_alpha;
+                                combined_Q_dfs *= theta;
                                 combined_Q_dfs += Q_dfs;
                             }
                         }
@@ -318,16 +327,17 @@ namespace nil {
                     typename LPC::basic_fri::params_type fri_params,
                     typename LPC::basic_fri::transcript_type &transcript = typename LPC::basic_fri::transcript_type()
                 ) {
-                    // if (t_polynomials != proof.T_root)
-                    //     return false; 
-                    //make a check for t_poly and T_root
+                    for( std::size_t k = 0; k < LPC::basic_fri::batches_num; k++){
+                        transcript(commitments[k]);
+                    }
 
                     typename std::vector<std::size_t> evals_map;
                     typename std::vector<std::vector<typename LPC::field_type::value_type>> unique_eval_points;
                     typename std::vector<math::polynomial<typename LPC::field_type::value_type>> combined_U;
                     typename std::vector<math::polynomial<typename LPC::field_type::value_type>> denominators;
-                    typename LPC::field_type::value_type combined_alpha = transcript.template challenge<typename LPC::field_type>();
+                    typename LPC::field_type::value_type theta = transcript.template challenge<typename LPC::field_type>();
 
+//                    std::cout << "theta=" << theta.data << std::endl;
                     std::size_t batch_size = 0;
                     for( std::size_t k = 0; k < LPC::basic_fri::batches_num; k++){
                         BOOST_ASSERT( evaluation_points[k].size() == proof.z[k].size() || evaluation_points[k].size() == 1);
@@ -397,7 +407,7 @@ namespace nil {
                         std::size_t ind = 0;
                         for( std::size_t k = 0; k < LPC::basic_fri::batches_num; k++){
                             for( std::size_t i = 0; i < proof.z[k].size(); i++ ){
-                                combined_U[point_index] = combined_U[point_index] * combined_alpha;
+                                combined_U[point_index] = combined_U[point_index] * theta;
                                 if(evals_map[ind] == point_index){
                                     BOOST_ASSERT(proof.z[k][i].size() == unique_eval_points[point_index].size());
                                     for( std::size_t xi_index = 0; xi_index < unique_eval_points[point_index].size(); xi_index++ ){
@@ -406,6 +416,7 @@ namespace nil {
                                             proof.z[k][i][xi_index]
                                         );
                                     }
+                                    math::polynomial<typename LPC::field_type::value_type> U = math::lagrange_interpolation(U_interpolation_points);
                                     combined_U[point_index] = combined_U[point_index] + math::lagrange_interpolation(U_interpolation_points);
                                 }
                                 ind++;
@@ -417,7 +428,7 @@ namespace nil {
                         proof.fri_proof,
                         fri_params, 
                         commitments,
-                        combined_alpha,
+                        theta,
                         evals_map,
                         combined_U,
                         denominators,

--- a/include/nil/crypto3/zk/snark/systems/plonk/placeholder/gates_argument.hpp
+++ b/include/nil/crypto3/zk/snark/systems/plonk/placeholder/gates_argument.hpp
@@ -117,8 +117,8 @@ namespace nil {
                             std::uint32_t max_gates_degree,
                             transcript_type &transcript = transcript_type()) {
 
-                        std::uint32_t extended_domain_size = original_domain->m * std::pow(2, max_gates_degree);
-
+                        std::uint32_t extended_domain_size = original_domain->m * std::pow(2, ceil(std::log2(max_gates_degree)));
+                        
                         const plonk_polynomial_dfs_table<FieldType, typename ParamsType::arithmetization_params>
                             extended_column_polynomials = resize(column_polynomials, extended_domain_size);
 

--- a/include/nil/crypto3/zk/snark/systems/plonk/placeholder/profiling.hpp
+++ b/include/nil/crypto3/zk/snark/systems/plonk/placeholder/profiling.hpp
@@ -39,7 +39,8 @@ namespace nil {
                 template<typename PlaceholderParams>
                 struct placeholder_profiling;
 
-                template<typename FieldType, typename ArithmetizationParams, typename MerkleTreeHashType,
+
+/*              template<typename FieldType, typename ArithmetizationParams, typename MerkleTreeHashType,
                          typename TranscriptHashType, std::size_t Lambda, std::size_t R, std::size_t M>
                 struct placeholder_profiling<placeholder_params<FieldType, ArithmetizationParams, MerkleTreeHashType,
                                                                 TranscriptHashType, Lambda, R, M>> {
@@ -113,6 +114,58 @@ namespace nil {
                                      })
                                   << std::endl;
                     }
+*/
+
+                    template<typename FRI, typename TableDescriptionType, typename ColumnsRotationsType,
+                            typename ArithmetizationParams>
+                    void print_placeholder_params(typename FRI::params_type &fri_params, TableDescriptionType table_description,
+                                    ColumnsRotationsType &columns_rotations, std::string filename) {
+                        using FRIParamsType = typename FRI::params_type;
+                        std::ofstream out;
+
+                        out.open(filename);
+                        out << "{"
+                            << "\t\"_test_name\":\"Test name\"," << std::endl;
+                        out << "\t\"arithmetization_params\":[" << ArithmetizationParams::witness_columns << ","
+                            << ArithmetizationParams::public_input_columns << "," << ArithmetizationParams::constant_columns << ","
+                            << ArithmetizationParams::selector_columns << "]," << std::endl
+                            << "\t\"columns_rotations\":[";
+                        for (size_t i = 0; i < columns_rotations.size(); i++) {
+                            if (i != 0)
+                                out << ",";
+                            out << "[";
+                            for (size_t j = 0; j < columns_rotations[i].size(); j++) {
+                                if (j != 0)
+                                    out << ",";
+                                out << columns_rotations[i][j];
+                            }
+                            out << "]";
+                        }
+                        out << "]," << std::endl;
+                        out << "\t\"modulus\":" << FRI::field_type::modulus << "," << std::endl;
+                        out << "\t\"r\":" << fri_params.r << "," << std::endl;
+                        out << "\t\"m\":" << FRI::m << "," << std::endl;
+                        out << "\t\"lambda\":" << FRI::lambda << "," << std::endl;
+                        out << "\t\"batches_num\":" << FRI::batches_num << "," << std::endl;
+                        out << "\t\"step_list\":[";
+                        for (size_t i = 0; i < fri_params.step_list.size(); i++) {
+                            if (i != 0)
+                                out << ",";
+                            out << fri_params.step_list[i];
+                        }
+                        out << "]," << std::endl;
+                        out << "\t\"D_omegas\":[" << std::endl;
+                        for (size_t i = 0; i < fri_params.D.size(); i++) {
+                            if (i != 0)
+                                out << "," << std::endl;
+                            out << "\t\t" << fri_params.D[i]->get_domain_element(1).data;
+                        }
+                        out << std::endl << "\t]," << std::endl;
+                        out << "\t\"rows_amount\":" << table_description.rows_amount << "," << std::endl;
+                        out << "\t\"max_degree\":" << fri_params.max_degree << "," << std::endl;
+                        out << "\t\"omega\":" << fri_params.D[0]->get_domain_element(1).data << std::endl;
+                        out << "}" << std::endl;
+                        out.close();
                 };
             }    // namespace snark
         }        // namespace zk

--- a/include/nil/crypto3/zk/snark/systems/plonk/placeholder/proof.hpp
+++ b/include/nil/crypto3/zk/snark/systems/plonk/placeholder/proof.hpp
@@ -71,20 +71,18 @@ namespace nil {
 
                     typename commitment_scheme_type::commitment_type variable_values_commitment;
                     typename commitment_scheme_type::commitment_type v_perm_commitment;
-                    typename commitment_scheme_type::commitment_type input_perm_commitment;
-                    typename commitment_scheme_type::commitment_type value_perm_commitment;
-                    typename commitment_scheme_type::commitment_type v_l_perm_commitment;
                     typename commitment_scheme_type::commitment_type T_commitment;
+                    typename commitment_scheme_type::commitment_type fixed_values_commitment;
 
                     evaluation_proof eval_proof;
 
                     bool operator==(const placeholder_proof &rhs) const {
                         return /*witness_commitment == rhs.witness_commitment &&*/
-                               v_perm_commitment == rhs.v_perm_commitment &&
-                               input_perm_commitment == rhs.input_perm_commitment &&
-                               value_perm_commitment == rhs.value_perm_commitment &&
-                               v_l_perm_commitment == rhs.v_l_perm_commitment && T_commitment == rhs.T_commitment &&
-                               eval_proof == rhs.eval_proof;
+                            variable_values_commitment == rhs.variable_values_commitment &&
+                            v_perm_commitment == rhs.v_perm_commitment &&
+                            T_commitment == rhs.T_commitment &&
+                            fixed_values_commitment == rhs.fixed_values_commitment &&
+                            eval_proof == rhs.eval_proof;
                     }
                     bool operator!=(const placeholder_proof &rhs) const {
                         return !(rhs == *this);

--- a/include/nil/crypto3/zk/snark/systems/plonk/placeholder/prover.hpp
+++ b/include/nil/crypto3/zk/snark/systems/plonk/placeholder/prover.hpp
@@ -465,6 +465,8 @@ namespace nil {
                             preprocessed_public_data.precommitments.fixed_values
                         };
 
+                        proof.fixed_values_commitment = preprocessed_public_data.common_data.commitments.fixed_values;
+
                         proof.eval_proof.combined_value = algorithms::proof_eval<commitment_scheme_type>(
                                                     evaluations_points,
                                                     precommitments,

--- a/include/nil/crypto3/zk/snark/systems/plonk/placeholder/prover.hpp
+++ b/include/nil/crypto3/zk/snark/systems/plonk/placeholder/prover.hpp
@@ -71,6 +71,7 @@ namespace nil {
                     constexpr static const std::size_t witness_columns = ParamsType::witness_columns;
                     constexpr static const std::size_t public_columns = ParamsType::public_columns;
                     constexpr static const std::size_t public_input_columns = ParamsType::public_input_columns;
+                    constexpr static const std::size_t constant_columns = ParamsType::constant_columns;
                     using merkle_hash_type = typename ParamsType::merkle_hash_type;
                     using transcript_hash_type = typename ParamsType::transcript_hash_type;
 
@@ -345,8 +346,7 @@ namespace nil {
                             variable_values_evaluation_points(witness_columns + public_input_columns);
 
                         // variable_values polynomials (table columns)
-                        for (std::size_t variable_values_index = 0; variable_values_index < witness_columns; variable_values_index++) {
-
+                        for (std::size_t variable_values_index = 0; variable_values_index < witness_columns + public_input_columns; variable_values_index++) {
                             std::vector<int> variable_values_rotation =
                                 preprocessed_public_data.common_data.columns_rotations[variable_values_index];
 
@@ -355,9 +355,6 @@ namespace nil {
                                 variable_values_evaluation_points[variable_values_index].push_back(
                                     challenge * omega.pow(variable_values_rotation[rotation_index]));
                             }
-                        }
-                        for (std::size_t i = witness_columns; i < witness_columns + public_input_columns; i ++) {
-                            variable_values_evaluation_points[i].push_back(challenge);
                         }
 #ifdef ZK_PLACEHOLDER_PROFILING_ENABLED
                         elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -430,32 +427,53 @@ namespace nil {
                         }
 
                         // quotient
-                        std::vector<std::vector<typename FieldType::value_type>> evaluation_points_quotient = {{challenge}};
+                        std::vector<typename FieldType::value_type> challenge_point = {challenge};
+                        std::vector<std::vector<typename FieldType::value_type>> evaluation_points_quotient = {challenge_point};
                         for (std::size_t k = 0; k < T_splitted.size(); k++) {
                             combined_poly[2].push_back(T_splitted_dfs[k]);
                         }
                         // public
-                        std::vector<std::vector<typename FieldType::value_type>> &evaluation_points_public =
-                            evaluation_points_quotient;
+                        std::vector<std::vector<typename FieldType::value_type>> evaluation_points_public;
 
                         for (std::size_t k = 0; k < preprocessed_public_data.identity_polynomials.size(); k++) {
                             combined_poly[3].push_back(preprocessed_public_data.identity_polynomials[k]);
+                            evaluation_points_public.push_back(challenge_point);
                         }
                         
                         for (std::size_t k = 0; k < preprocessed_public_data.identity_polynomials.size(); k++) {
                             combined_poly[3].push_back(preprocessed_public_data.permutation_polynomials[k]);
+                            evaluation_points_public.push_back(challenge_point);
                         }
 
-                        for (std::size_t k = 0; k < preprocessed_public_data.public_polynomial_table.constants().size(); k ++){
+                        for (std::size_t k = 0; k < constant_columns; k ++){
                             combined_poly[3].push_back(preprocessed_public_data.public_polynomial_table.constants()[k]);
+                            std::vector<int> rotation =
+                                preprocessed_public_data.common_data.columns_rotations[witness_columns + public_input_columns + k];
+                            std::vector<typename FieldType::value_type> point;
+
+                            for (std::size_t rotation_index = 0; rotation_index < rotation.size(); rotation_index++) {
+                                point.push_back( challenge * omega.pow(rotation[rotation_index]));
+                            }
+                            evaluation_points_public.push_back(point);
                         }
                         
                         for (std::size_t k = 0; k < preprocessed_public_data.public_polynomial_table.selectors().size(); k ++){
                             combined_poly[3].push_back(preprocessed_public_data.public_polynomial_table.selectors()[k]);
+                            std::vector<int> rotation =
+                                preprocessed_public_data.common_data.columns_rotations[witness_columns + public_input_columns + constant_columns + k];
+                            std::vector<typename FieldType::value_type> point;
+
+                            for (std::size_t rotation_index = 0; rotation_index < rotation.size(); rotation_index++) {
+                                point.push_back( challenge * omega.pow(rotation[rotation_index]));
+                            }
+                            evaluation_points_public.push_back(point);
                         }
 
                         combined_poly[3].push_back(preprocessed_public_data.q_last);
+                        evaluation_points_public.push_back(challenge_point);
                         combined_poly[3].push_back(preprocessed_public_data.q_blind);
+                        evaluation_points_public.push_back(challenge_point);
+
                         std::array<std::vector<std::vector<typename FieldType::value_type>>, 4> evaluations_points =
                         {variable_values_evaluation_points, evaluation_points_v_p, evaluation_points_quotient, evaluation_points_public};
                         std::array<typename commitment_scheme_type::precommitment_type, 4> precommitments = {

--- a/include/nil/crypto3/zk/snark/systems/plonk/placeholder/verifier.hpp
+++ b/include/nil/crypto3/zk/snark/systems/plonk/placeholder/verifier.hpp
@@ -288,13 +288,21 @@ namespace nil {
                         std::array<std::vector<std::vector<typename FieldType::value_type>>, 4> evaluations_points =
                         {variable_values_evaluation_points, evaluation_points_permutation, evaluation_points_quotient, evaluation_points_public};
                         std::array<typename commitment_scheme_type::commitment_type, 4> commitments = 
-                        {proof.variable_values_commitment, proof.v_perm_commitment,
-                                                    proof.T_commitment, preprocessed_public_data.common_data.commitments.fixed_values};
+                        {proof.variable_values_commitment, 
+                         proof.v_perm_commitment,
+                         proof.T_commitment, 
+                         preprocessed_public_data.common_data.commitments.fixed_values
+                        };
+                        
+                        if( proof.fixed_values_commitment != preprocessed_public_data.common_data.commitments.fixed_values )
+                            return false;
+
                         if (!algorithms::verify_eval<commitment_scheme_type>(
-                                evaluations_points,
-                                proof.eval_proof.combined_value,
-                                                    commitments,
-                                                    fri_params, transcript)) {
+                            evaluations_points,
+                            proof.eval_proof.combined_value,
+                            commitments,
+                            fri_params, transcript)
+                        ) {
                             return false;
                         }
 

--- a/include/nil/crypto3/zk/snark/systems/plonk/placeholder/verifier.hpp
+++ b/include/nil/crypto3/zk/snark/systems/plonk/placeholder/verifier.hpp
@@ -224,7 +224,6 @@ namespace nil {
 
                         // variable_values polynomials (table columns)
                         for (std::size_t variable_values_index = 0; variable_values_index < witness_columns + public_input_columns; variable_values_index++) {
-
                             std::vector<int> variable_values_rotation =
                                 preprocessed_public_data.common_data.columns_rotations[variable_values_index];
 

--- a/include/nil/crypto3/zk/snark/systems/plonk/placeholder/verifier.hpp
+++ b/include/nil/crypto3/zk/snark/systems/plonk/placeholder/verifier.hpp
@@ -223,7 +223,7 @@ namespace nil {
                             variable_values_evaluation_points(witness_columns + public_input_columns);
 
                         // variable_values polynomials (table columns)
-                        for (std::size_t variable_values_index = 0; variable_values_index < witness_columns; variable_values_index++) {
+                        for (std::size_t variable_values_index = 0; variable_values_index < witness_columns + public_input_columns; variable_values_index++) {
 
                             std::vector<int> variable_values_rotation =
                                 preprocessed_public_data.common_data.columns_rotations[variable_values_index];
@@ -234,10 +234,6 @@ namespace nil {
                                     challenge * omega.pow(variable_values_rotation[rotation_index]));
                             }
                         }
-                        for (std::size_t i = witness_columns; i < witness_columns + public_input_columns; i ++) {
-                            variable_values_evaluation_points[i].push_back(challenge);
-                        }
-
                         // permutation
                         std::vector<std::vector<typename FieldType::value_type>> evaluation_points_permutation = {{challenge,
                                                                                                      challenge * omega}};

--- a/include/nil/crypto3/zk/snark/systems/plonk/placeholder/verifier.hpp
+++ b/include/nil/crypto3/zk/snark/systems/plonk/placeholder/verifier.hpp
@@ -275,12 +275,50 @@ namespace nil {
                             // }
                         }
 
+                        std::vector<typename FieldType::value_type> challenge_point = {challenge};
+
                         // quotient
-                        std::vector<std::vector<typename FieldType::value_type>> evaluation_points_quotient = {{challenge}};
+                        std::vector<std::vector<typename FieldType::value_type>> evaluation_points_quotient = {challenge_point};
 
                         // public data
-                        std::vector<std::vector<typename FieldType::value_type>> &evaluation_points_public =
-                            evaluation_points_quotient;
+                        std::vector<std::vector<typename FieldType::value_type>> evaluation_points_public;
+
+                        for (std::size_t k = 0; k < preprocessed_public_data.identity_polynomials.size(); k++) {
+                            evaluation_points_public.push_back(challenge_point);
+                        }
+                        
+                        for (std::size_t k = 0; k < preprocessed_public_data.identity_polynomials.size(); k++) {
+                            evaluation_points_public.push_back(challenge_point);
+                        }
+
+                        // constant columns may be rotated
+                        for (std::size_t k = 0; k < constant_columns; k ++){
+                            std::vector<int> rotation =
+                                preprocessed_public_data.common_data.columns_rotations[witness_columns + public_input_columns + k];
+                            std::vector<typename FieldType::value_type> point;
+
+                            for (std::size_t rotation_index = 0; rotation_index < rotation.size(); rotation_index++) {
+                                point.push_back( challenge * omega.pow(rotation[rotation_index]));
+                            }
+                            evaluation_points_public.push_back(point);
+                        }
+                        
+                        // selector columns may be rotated
+                        for (std::size_t k = 0; k < selector_columns; k ++){
+                            std::vector<int> rotation =
+                                preprocessed_public_data.common_data.columns_rotations[witness_columns + public_input_columns + constant_columns + k];
+                            std::vector<typename FieldType::value_type> point;
+
+                            for (std::size_t rotation_index = 0; rotation_index < rotation.size(); rotation_index++) {
+                                point.push_back( challenge * omega.pow(rotation[rotation_index]));
+                            }
+                            evaluation_points_public.push_back(point);
+                        }
+
+                        // Evaluation points for special selectors q_last and q_blind
+                        evaluation_points_public.push_back(challenge_point); // for q_last
+                        evaluation_points_public.push_back(challenge_point); // for q_blind
+
                         std::array<std::vector<std::vector<typename FieldType::value_type>>, 4> evaluations_points =
                         {variable_values_evaluation_points, evaluation_points_permutation, evaluation_points_quotient, evaluation_points_public};
                         std::array<typename commitment_scheme_type::commitment_type, 4> commitments = 

--- a/test/commitment/lpc.cpp
+++ b/test/commitment/lpc.cpp
@@ -134,11 +134,11 @@ boost::random::mt11213b test_global_rnd_engine;
 template <typename FieldType>
 nil::crypto3::random::algebraic_engine<FieldType> test_global_alg_rnd_engine;
 
-struct test_initializer {
+struct test_fixture {
     // Enumerate all fields used in tests;
     using field1_type = algebra::curves::bls12<381>::scalar_field_type;
 
-    test_initializer(){
+    test_fixture(){
         test_global_seed = 0;
 
         for( std::size_t i = 0; i < boost::unit_test::framework::master_test_suite().argc - 1; i++){
@@ -146,6 +146,7 @@ struct test_initializer {
                 if(std::string(boost::unit_test::framework::master_test_suite().argv[i+1]) == "random"){
                     std::random_device rd;
                     test_global_seed = rd();
+                    std::cout << "Random seed=" << test_global_seed << std::endl;
                     break;
                 }
                 if(std::regex_match( boost::unit_test::framework::master_test_suite().argv[i+1], std::regex( ( "((\\+|-)?[[:digit:]]+)(\\.(([[:digit:]]+)?))?" ) ) ) ){
@@ -159,18 +160,12 @@ struct test_initializer {
         test_global_rnd_engine  = boost::random::mt11213b(test_global_seed);
         test_global_alg_rnd_engine<field1_type> = nil::crypto3::random::algebraic_engine<field1_type>(test_global_seed);
     }
-    void setup(){
-    }
-    void teardown(){
-    }
-    ~test_initializer(){}
+    ~test_fixture(){}
 };
-
-BOOST_TEST_GLOBAL_FIXTURE(test_initializer);
 
 BOOST_AUTO_TEST_SUITE(lpc_math_polynomial_suite);
 
-BOOST_AUTO_TEST_CASE(lpc_basic_test) {
+BOOST_FIXTURE_TEST_CASE(lpc_basic_test, test_fixture) {
     // Setup types.
     typedef algebra::curves::bls12<381> curve_type;
     typedef typename curve_type::scalar_field_type FieldType;
@@ -264,7 +259,7 @@ BOOST_AUTO_TEST_CASE(lpc_basic_test) {
     BOOST_CHECK(verifier_next_challenge == prover_next_challenge);
 }
 
-BOOST_AUTO_TEST_CASE(lpc_basic_skipping_layers_test) {
+BOOST_FIXTURE_TEST_CASE(lpc_basic_skipping_layers_test, test_fixture) {
     // Setup types
     typedef algebra::curves::bls12<381> curve_type;
     typedef typename curve_type::scalar_field_type FieldType;
@@ -274,7 +269,7 @@ BOOST_AUTO_TEST_CASE(lpc_basic_skipping_layers_test) {
 
     typedef typename containers::merkle_tree<merkle_hash_type, 2> merkle_tree_type;
 
-    constexpr static const std::size_t lambda = 40;
+    constexpr static const std::size_t lambda = 10;
     constexpr static const std::size_t k = 1;
 
     constexpr static const std::size_t d = 2048;
@@ -358,7 +353,7 @@ BOOST_AUTO_TEST_CASE(lpc_basic_skipping_layers_test) {
     BOOST_CHECK(verifier_next_challenge == prover_next_challenge);
 }
 
-BOOST_AUTO_TEST_CASE(lpc_dfs_basic_test) {
+BOOST_FIXTURE_TEST_CASE(lpc_dfs_basic_test, test_fixture) {
 
     // Setup types
     typedef algebra::curves::bls12<381> curve_type;
@@ -456,7 +451,7 @@ BOOST_AUTO_TEST_SUITE_END()
 
 
 BOOST_AUTO_TEST_SUITE(lpc_params_test_suite)
-BOOST_AUTO_TEST_CASE(lpc_batches_num_3_test){
+BOOST_FIXTURE_TEST_CASE(lpc_batches_num_3_test, test_fixture){
     // Setup types.
     typedef algebra::curves::bls12<381> curve_type;
     typedef typename curve_type::scalar_field_type FieldType;
@@ -517,6 +512,7 @@ BOOST_AUTO_TEST_CASE(lpc_batches_num_3_test){
     // Generate evaluation points. Generate points outside of the basic domain
     std::vector<typename FieldType::value_type> evaluation_point;
     evaluation_point.push_back(algebra::fields::arithmetic_params<FieldType>::multiplicative_generator);
+
     std::array<std::vector<std::vector<typename FieldType::value_type>>, 3> evaluation_points;
     evaluation_points[0].push_back(evaluation_point);
     evaluation_points[1].push_back(evaluation_point);
@@ -532,6 +528,100 @@ BOOST_AUTO_TEST_CASE(lpc_batches_num_3_test){
     commitment[0] = zk::algorithms::commit<lpc_type>(tree[0]);
     commitment[1] = zk::algorithms::commit<lpc_type>(tree[1]);
     commitment[2] = zk::algorithms::commit<lpc_type>(tree[2]);
+    
+    // Verify
+    zk::transcript::fiat_shamir_heuristic_sequential<transcript_hash_type> transcript_verifier(x_data);
+    BOOST_CHECK(zk::algorithms::verify_eval<lpc_type>(
+        evaluation_points, proof, commitment, fri_params, transcript_verifier
+    ));
+
+    // Check transcript state
+    typename FieldType::value_type verifier_next_challenge = transcript_verifier.template challenge<FieldType>();
+    typename FieldType::value_type prover_next_challenge = transcript.template challenge<FieldType>();
+    BOOST_CHECK(verifier_next_challenge == prover_next_challenge);
+}
+
+BOOST_FIXTURE_TEST_CASE(lpc_different_hash_types_test, test_fixture) {
+    // Setup types.
+    typedef algebra::curves::bls12<381> curve_type;
+    typedef typename curve_type::scalar_field_type FieldType;
+    typedef hashes::keccak_1600<256> merkle_hash_type;
+    typedef hashes::sha2<256> transcript_hash_type;
+    typedef typename containers::merkle_tree<merkle_hash_type, 2> merkle_tree_type;
+
+    constexpr static const std::size_t lambda = 10;
+    constexpr static const std::size_t k = 1;
+
+    constexpr static const std::size_t d = 16;
+    constexpr static const std::size_t r = boost::static_log2<(d - k)>::value;
+    
+    constexpr static const std::size_t m = 2;
+
+    typedef zk::commitments::fri<FieldType, merkle_hash_type, transcript_hash_type, lambda, m, 4> fri_type;
+
+    typedef zk::commitments::
+        list_polynomial_commitment_params<merkle_hash_type, transcript_hash_type, lambda, r, m, 4>
+            lpc_params_type;
+    typedef zk::commitments::list_polynomial_commitment<FieldType, lpc_params_type> lpc_type;
+
+    static_assert(zk::is_commitment<fri_type>::value);
+    static_assert(zk::is_commitment<lpc_type>::value);
+    static_assert(!zk::is_commitment<merkle_hash_type>::value);
+    static_assert(!zk::is_commitment<merkle_tree_type>::value);
+    static_assert(!zk::is_commitment<std::size_t>::value);
+
+    typedef typename lpc_type::proof_type proof_type;
+
+    constexpr static const std::size_t d_extended = d;
+    std::size_t extended_log = boost::static_log2<d_extended>::value;
+    std::vector<std::shared_ptr<math::evaluation_domain<FieldType>>> D =
+        math::calculate_domain_set<FieldType>(extended_log, r);
+
+    typename fri_type::params_type fri_params;
+
+    // Setup params
+    fri_params.r = r;
+    fri_params.D = D;
+    fri_params.max_degree = d - 1;
+    fri_params.step_list = generate_random_step_list(r, 1, test_global_rnd_engine);
+
+    // Generate polynomials
+    std::array<std::vector<math::polynomial<typename FieldType::value_type>>,4> f;
+    f[0].push_back({1, 13, 4, 1, 5, 6, 7, 2, 8, 7, 5, 6, 1, 2, 1, 1});
+    f[1].push_back({0, 1});
+    f[1].push_back({0, 1, 2});
+    f[1].push_back({0, 1, 3});
+    f[2].push_back({0});
+    f[3].push_back(generate_random_polynomial(4, test_global_alg_rnd_engine<FieldType>));
+    f[3].push_back(generate_random_polynomial(9, test_global_alg_rnd_engine<FieldType>));
+
+    // Commit
+    std::array<merkle_tree_type,4> tree;
+    tree[0] = zk::algorithms::precommit<lpc_type>(f[0], D[0], fri_params.step_list.front());
+    tree[1] = zk::algorithms::precommit<lpc_type>(f[1], D[0], fri_params.step_list.front());
+    tree[2] = zk::algorithms::precommit<lpc_type>(f[2], D[0], fri_params.step_list.front());
+    tree[3] = zk::algorithms::precommit<lpc_type>(f[3], D[0], fri_params.step_list.front());
+
+    // Generate evaluation points. Generate points outside of the basic domain
+    std::vector<typename FieldType::value_type> evaluation_point;
+    evaluation_point.push_back(algebra::fields::arithmetic_params<FieldType>::multiplicative_generator);
+    std::array<std::vector<std::vector<typename FieldType::value_type>>, 4> evaluation_points;
+    evaluation_points[0].push_back(evaluation_point);
+    evaluation_points[1].push_back(evaluation_point);
+    evaluation_points[2].push_back(evaluation_point);
+    evaluation_points[3].push_back(evaluation_point);
+
+    std::array<std::uint8_t, 96> x_data {};
+
+    // Prove
+    zk::transcript::fiat_shamir_heuristic_sequential<transcript_hash_type> transcript(x_data);
+    auto proof = zk::algorithms::proof_eval<lpc_type>(evaluation_points, tree, f, fri_params, transcript);
+
+    std::array<typename lpc_type::commitment_type, 4> commitment;
+    commitment[0] = zk::algorithms::commit<lpc_type>(tree[0]);
+    commitment[1] = zk::algorithms::commit<lpc_type>(tree[1]);
+    commitment[2] = zk::algorithms::commit<lpc_type>(tree[2]);
+    commitment[3] = zk::algorithms::commit<lpc_type>(tree[3]);
     
     // Verify
     zk::transcript::fiat_shamir_heuristic_sequential<transcript_hash_type> transcript_verifier(x_data);


### PR DESCRIPTION
1. Lpc transcript calls was a bit changed. Batches' roots are pushed to transcript before theta generation
2. Columns rotations logic modified. All columns can be rotated now.
3. LPC/FRI tests added.
4. Parameters profiling changed. 
5. Gate argument extended_domain_size calculation modified.