### PR TITLE
In LPC proof instead of dividing by V, divide by smaller polynomials.

### DIFF
--- a/include/nil/crypto3/zk/commitments/batched_commitment.hpp
+++ b/include/nil/crypto3/zk/commitments/batched_commitment.hpp
@@ -59,19 +59,35 @@ namespace nil {
                     using poly_type = PolynomialType;
 
                     eval_storage<field_type> _z;
-                    polys_evaluator(){}
+
+                    polys_evaluator() = default;
+
                 protected:
                     std::map<std::size_t, std::vector<poly_type>> _polys;
                     std::map<std::size_t, bool> _locked; // _locked[batch] is true after it is commited
                     std::map<std::size_t, std::vector<std::vector<typename field_type::value_type>>> _points;
+
                 protected:
                     math::polynomial<typename field_type::value_type> get_V(const std::vector<typename field_type::value_type> &points) const{
                         math::polynomial<typename field_type::value_type> V = {1};
                         for( std::size_t xi_index = 0; xi_index < points.size(); xi_index++ ){
-                            V = V * math::polynomial<typename field_type::value_type>({-points[xi_index], 1});
+                            V *= math::polynomial<typename field_type::value_type>({-points[xi_index], 1});
                         }
                         return V;
                     }
+
+                    std::vector<math::polynomial<typename field_type::value_type>> get_V_multipliers(
+                        const std::vector<typename field_type::value_type> &points) const {
+
+                        std::vector<math::polynomial<typename field_type::value_type>> V_multipliers;
+                        for( std::size_t xi_index = 0; xi_index < points.size(); xi_index++ ){
+                            V_multipliers.push_back(math::polynomial<typename field_type::value_type>(
+                                {-points[xi_index], 1}));
+                        }
+                        return V_multipliers;
+                    }
+
+
                     math::polynomial<typename field_type::value_type> get_U(std::size_t b_ind, std::size_t poly_ind) const{
                         const auto &points = _points.at(b_ind)[poly_ind];
                         BOOST_ASSERT(points.size() == this->_z.get_poly_points_number(b_ind, poly_ind));

--- a/include/nil/crypto3/zk/commitments/polynomial/lpc.hpp
+++ b/include/nil/crypto3/zk/commitments/polynomial/lpc.hpp
@@ -95,22 +95,25 @@ namespace nil {
                     }
 
                     proof_type proof_eval(transcript_type &transcript) {
-                        for( auto const&it: _batch_fixed){
+                        for(auto const& it: _batch_fixed) {
                             if(it.second){
                                 this->append_eval_point(it.first, _etha);
                             }
                         }
+
                         this->eval_polys();
+
                         BOOST_ASSERT(this->_points.size() == this->_polys.size());
                         BOOST_ASSERT(this->_points.size() == this->_z.get_batches_num());
 
-                        for( auto const&it: this->_trees){
+                        for(auto const& it: this->_trees) {
                             transcript(it.second.root());
                         }
 
                         // Prepare z-s and combined_Q;
                         auto theta = transcript.template challenge<field_type>();
                         poly_type combined_Q;
+
                         if constexpr (std::is_same<math::polynomial_dfs<value_type>, PolynomialType>::value
                         ) {
                             bool first = true;
@@ -125,13 +128,16 @@ namespace nil {
                                     auto& points = this->_points[b_ind][poly_ind];
                                     BOOST_ASSERT(points.size() == this->_z.get_poly_points_number(b_ind, poly_ind));
 
-                                    math::polynomial<value_type> V = this->get_V(this->_points[b_ind][poly_ind]);
-                                    math::polynomial<value_type> U =  this->get_U(b_ind, poly_ind);
+                                    std::vector<math::polynomial<value_type>> V_multipliers = this->get_V_multipliers(points);
+
+                                    math::polynomial<value_type> U = this->get_U(b_ind, poly_ind);
 
                                     math::polynomial<value_type> g_normal(this->_polys[b_ind][poly_ind].coefficients());
                                     math::polynomial<value_type> Q = g_normal - this->get_U(b_ind, poly_ind);
 
-                                    Q = Q / this->get_V(this->_points[b_ind][poly_ind]);
+                                    for (const auto& V_mult: V_multipliers) {
+                                        Q /= V_mult;
+                                    }
 
                                     math::polynomial_dfs<value_type> Q_dfs(0, _fri_params.D[0]->size());
                                     Q_dfs.from_coefficients(Q);
@@ -147,22 +153,29 @@ namespace nil {
                             }
                         } else {
                             bool first = true;
+
                             // prepare U and V
-                            for(auto const &it: this->_polys){
+                            for(auto const &it: this->_polys) {
                                 auto b_ind = it.first;
+
                                 BOOST_ASSERT(this->_points[b_ind].size() == this->_polys[b_ind].size());
                                 BOOST_ASSERT(this->_points[b_ind].size() == this->_z.get_batch_size(b_ind));
-                                for( std::size_t poly_ind = 0; poly_ind < this->_polys[b_ind].size(); poly_ind++){
+
+                                for(std::size_t poly_ind = 0; poly_ind < this->_polys[b_ind].size(); poly_ind++) {
                                     // All evaluation points are filled successfully.
-                                    auto points = this->_points[b_ind][poly_ind];
+                                    const auto& points = this->_points[b_ind][poly_ind];
                                     BOOST_ASSERT(points.size() == this->_z.get_poly_points_number(b_ind, poly_ind));
 
-                                    math::polynomial<value_type> V = this->get_V(this->_points[b_ind][poly_ind]);
+                                    std::vector<math::polynomial<value_type>> V_multipliers = this->get_V_multipliers(points);
                                     math::polynomial<value_type> U =  this->get_U(b_ind, poly_ind);
 
                                     math::polynomial<value_type> g_normal = this->_polys[b_ind][poly_ind];
                                     math::polynomial<value_type> Q = g_normal - U;
-                                    Q = Q / V;
+
+                                    for (const auto& V_mult: V_multipliers) {
+                                        Q /= V_mult;
+                                    }
+
                                     if (first) {
                                         first = false;
                                         combined_Q = Q;
@@ -198,13 +211,14 @@ namespace nil {
                         const std::map<std::size_t, commitment_type> &commitments,
                         transcript_type &transcript
                     ) {
-                        for( auto const&it: _batch_fixed){
-                            if(it.second){
+                        for (auto const&it: _batch_fixed) {
+                            if(it.second) {
                                 this->append_eval_point(it.first, _etha);
                             }
                         }
+
                         this->_z = proof.z;
-                        for( auto const &it: commitments){
+                        for (auto const &it: commitments) {
                             transcript(commitments.at(it.first));
                         }
 
@@ -221,18 +235,19 @@ namespace nil {
 
                         combined_U.resize(unique_points.size());
                         denominators.resize(unique_points.size());
+
                         // For each eval_point compute combined_U
-                        for(std::size_t point_index = 0; point_index < unique_points.size(); point_index++ ){
+                        for (std::size_t point_index = 0; point_index < unique_points.size(); point_index++) {
                             // Compute V
                             denominators[point_index] = this->get_V(unique_points[point_index]);
                             combined_U[point_index] = {0};
 
                             for( auto const &it: this->_points){
                                 auto k = it.first;
-                                for( std::size_t i = 0; i < proof.z.get_batch_size(k); i++ ){
-                                    combined_U[point_index] =  combined_U[point_index] * theta;
-                                    if(eval_map[k][i] == point_index){
-                                        combined_U[point_index] = combined_U[point_index] + this->get_U(k,i);
+                                for(std::size_t i = 0; i < proof.z.get_batch_size(k); i++) {
+                                    combined_U[point_index] *= theta;
+                                    if (eval_map[k][i] == point_index) {
+                                        combined_U[point_index] += this->get_U(k,i);
                                     }
                                 }
                             }
@@ -392,294 +407,6 @@ namespace nil {
                 template<typename FieldType, typename LPCParams>
                 using list_polynomial_commitment = batched_list_polynomial_commitment<FieldType, LPCParams>;
             }    // namespace commitments
-
-            namespace algorithms {
-/*                template<
-                    typename LPC,
-                    typename ContainerType,    // TODO: check for value_type == std::vector<typename
-                                               // LPC::field_type::value_type>?
-                    typename std::enable_if<std::is_base_of<commitments::batched_list_polynomial_commitment<
-                                                            typename LPC::field_type, typename LPC::lpc_params>,
-                                                            LPC>::value &&
-                                                std::is_same_v<typename ContainerType::value_type,
-                                                        std::vector<typename LPC::field_type::value_type>>,
-                                bool>::type = true>
-                static typename LPC::proof_type proof_eval(
-                        const std::array<ContainerType, LPC::basic_fri::batches_num> &evaluation_points,
-                        const std::array<typename LPC::precommitment_type, LPC::basic_fri::batches_num> &precommitments,
-                        std::array<std::vector<math::polynomial<typename LPC::field_type::value_type>>, LPC::basic_fri::batches_num> &g,
-                        const typename LPC::basic_fri::params_type &fri_params,
-                        typename LPC::basic_fri::transcript_type &transcript) {
-
-                    for (std::size_t i = 0; i < LPC::basic_fri::batches_num; i++) {
-                        transcript(commit<typename LPC::basic_fri>(precommitments[i]));
-                    }
-                    typename LPC::field_type::value_type theta = transcript.template challenge<typename LPC::field_type>();
-                    math::polynomial<typename LPC::field_type::value_type> combined_Q;
-                    std::array<typename LPC::proof_type::z_type, LPC::basic_fri::batches_num> z;
-
-                    math::polynomial<typename LPC::field_type::value_type> combined_U = {0};
-                    for (std::size_t k = 0; k < LPC::basic_fri::batches_num; k++) {
-                        z[k].resize(g[k].size());
-                        for (std::size_t polynom_index = 0; polynom_index < g[k].size(); polynom_index++) {
-                            auto evaluation_point = evaluation_points[k][0];
-                            if (polynom_index < evaluation_points[k].size()) {
-                                evaluation_point = evaluation_points[k][polynom_index];
-                            }
-
-                            std::vector<std::pair<typename LPC::field_type::value_type, typename LPC::field_type::value_type>> U_interpolation_points;
-                            U_interpolation_points.resize(evaluation_point.size());
-                            z[k][polynom_index].resize(evaluation_point.size());
-
-                            for (std::size_t point_index = 0; point_index < evaluation_point.size(); point_index++) {
-                        
-                                z[k][polynom_index][point_index] = g[k][polynom_index].evaluate(
-                                    evaluation_point[point_index]
-                                );    // transform to point-representation
-
-                                U_interpolation_points[point_index] =
-                                    std::make_pair(evaluation_point[point_index], z[k][polynom_index][point_index]);    // prepare points for interpolation
-                            }
-
-                            math::polynomial<typename LPC::field_type::value_type> Q;
-                            math::polynomial<typename LPC::field_type::value_type> U = math::lagrange_interpolation(
-                                    U_interpolation_points);
-
-                            Q = g[k][polynom_index] - U;
-                            combined_U = combined_U * theta;
-                            combined_U = combined_U + U;
-
-                            math::polynomial<typename LPC::field_type::value_type> denominator_polynom = {1};
-                            for (std::size_t point_index = 0; point_index < evaluation_point.size(); point_index++) {
-                                denominator_polynom =
-                                        denominator_polynom * math::polynomial<typename LPC::field_type::value_type>{
-                                                -evaluation_point[point_index], 1};
-                            }
-
-                            Q = Q / denominator_polynom;
-                            if (k == 0 && polynom_index == 0) {
-                                combined_Q = Q;
-                            } else {
-                                combined_Q = combined_Q * theta + Q;
-                            }
-                        }
-                    }
-                    typename LPC::basic_fri::proof_type fri_proof;
-                    typename LPC::precommitment_type combined_Q_precommitment =
-                            precommit<typename LPC::basic_fri>(combined_Q, fri_params.D[0],
-                                                               fri_params.step_list.front());
-
-                    fri_proof = proof_eval<typename LPC::basic_fri, math::polynomial<typename LPC::field_type::value_type>>(
-                            g,
-                            combined_Q,
-                            precommitments,
-                            combined_Q_precommitment,
-                            fri_params,
-                            transcript
-                    );
-                    return typename LPC::proof_type({z, fri_proof});
-                }
-
-                template<typename LPC, typename std::enable_if<
-                        std::is_base_of<commitments::batched_list_polynomial_commitment<
-                                typename LPC::field_type, typename LPC::lpc_params>,
-                                LPC>::value,
-                        bool>::type = true>
-                static typename LPC::proof_type proof_eval(
-                        std::array<std::vector<std::vector<typename LPC::field_type::value_type>>, LPC::basic_fri::batches_num> &evaluation_points,
-                        const std::array<typename LPC::precommitment_type, LPC::basic_fri::batches_num> &precommitments,
-                        std::array<std::vector<math::polynomial_dfs<typename LPC::field_type::value_type>>, LPC::basic_fri::batches_num> &g,
-                        const typename LPC::basic_fri::params_type &fri_params,
-                        typename LPC::basic_fri::transcript_type &transcript) {
-                    for (std::size_t i = 0; i < LPC::basic_fri::batches_num; i++) {
-                        transcript(commit<typename LPC::basic_fri>(precommitments[i]));
-                    }
-
-                    // Prepare z-s and combined_Q;
-                    typename LPC::field_type::value_type theta = transcript.template challenge<typename LPC::field_type>();
-                    math::polynomial_dfs<typename LPC::field_type::value_type> combined_Q_dfs(
-                            0, fri_params.D[0]->size(),
-                            LPC::field_type::value_type::zero()
-                    );
-
-
-                    std::array<typename LPC::proof_type::z_type, LPC::basic_fri::batches_num> z;
-
-                    for (std::size_t k = 0; k < LPC::basic_fri::batches_num; k++) {
-                        z[k].resize(g[k].size());
-
-                        // Prepare U_interpolation_points and denominator_polynom
-                        for (std::size_t polynom_index = 0; polynom_index < g[k].size(); polynom_index++) {
-                            // Logic: Complex and different evaluation points may be only for the first polys in the batch. 
-                            // TODO : handle the case when only one evaluation_point. And not allow a
-                            auto evaluation_point = evaluation_points[k][0];
-                            if (polynom_index < evaluation_points[k].size()) {
-                                evaluation_point = evaluation_points[k][polynom_index];
-                            }
-
-                            // It's simple: list of {key, value} pairs
-                            std::vector<std::pair<typename LPC::field_type::value_type, typename LPC::field_type::value_type>> U_interpolation_points;
-
-                            U_interpolation_points.resize(evaluation_point.size());
-                            z[k][polynom_index].resize(evaluation_point.size());
-
-                            math::polynomial<typename LPC::field_type::value_type> g_normal(
-                                    g[k][polynom_index].coefficients());
-
-                            math::polynomial<typename LPC::field_type::value_type> V = {1};
-                            for (std::size_t point_index = 0; point_index < evaluation_point.size(); point_index++) {
-                                z[k][polynom_index][point_index] = g_normal.evaluate(evaluation_point[point_index]);
-                                U_interpolation_points[point_index] =
-                                        std::make_pair(evaluation_point[point_index],
-                                                       z[k][polynom_index][point_index]
-                                        );    // prepare points for interpolation
-                                V = V * math::polynomial<typename LPC::field_type::value_type>(
-                                        {-evaluation_point[point_index], 1});
-                            }
-                            math::polynomial<typename LPC::field_type::value_type> U =
-                                    math::lagrange_interpolation(U_interpolation_points);
-                            math::polynomial_dfs<typename LPC::field_type::value_type> U_dfs(0,
-                                                                                             fri_params.D[0]->size());
-                            U_dfs.from_coefficients(U);
-                            math::polynomial_dfs<typename LPC::field_type::value_type> denominator_dfs(0,
-                                                                                                       fri_params.D[0]->size());
-
-                            math::polynomial<typename LPC::field_type::value_type> Q = g_normal - U;
-                            Q = Q / V;
-                            math::polynomial_dfs<typename LPC::field_type::value_type> Q_dfs(0,
-                                                                                             fri_params.D[0]->size());
-                            Q_dfs.from_coefficients(Q);
-
-                            if (k == 0 && polynom_index == 0) {
-                                combined_Q_dfs = Q_dfs;
-                            } else {
-                                combined_Q_dfs *= theta;
-                                combined_Q_dfs += Q_dfs;
-                            }
-                        }
-                    }
-
-                    typename LPC::basic_fri::proof_type fri_proof;
-                    typename LPC::precommitment_type combined_Q_precommitment = precommit<typename LPC::basic_fri>(
-                            combined_Q_dfs,
-                            fri_params.D[0],
-                            fri_params.step_list.front()
-                    );
-
-                    fri_proof = proof_eval<typename LPC::basic_fri, math::polynomial_dfs<typename LPC::field_type::value_type>>(
-                            g,
-                            combined_Q_dfs,
-                            precommitments,
-                            combined_Q_precommitment,
-                            fri_params,
-                            transcript
-                    );
-                    return typename LPC::proof_type({z, fri_proof});
-                }
-
-                template<typename LPC>
-                static bool verify_eval(
-                        const std::array<std::vector<std::vector<typename LPC::field_type::value_type>>, LPC::basic_fri::batches_num> &evaluation_points,
-                        const typename LPC::proof_type &proof,
-                        const std::array<typename LPC::commitment_type, LPC::basic_fri::batches_num> &commitments,
-                        typename LPC::basic_fri::params_type fri_params,
-                        typename LPC::basic_fri::transcript_type &transcript) {
-
-                    for (std::size_t k = 0; k < LPC::basic_fri::batches_num; k++) {
-                        transcript(commitments[k]);
-                    }
-
-                    typename std::vector<std::size_t> evals_map;
-                    typename std::vector<std::vector<typename LPC::field_type::value_type>> unique_eval_points;
-                    typename std::vector<math::polynomial<typename LPC::field_type::value_type>> combined_U;
-                    typename std::vector<math::polynomial<typename LPC::field_type::value_type>> denominators;
-                    typename LPC::field_type::value_type theta = transcript.template challenge<typename LPC::field_type>();
-
-                    std::size_t batch_size = 0;
-                    for (std::size_t k = 0; k < LPC::basic_fri::batches_num; k++) {
-                        BOOST_ASSERT(
-                                evaluation_points[k].size() == proof.z[k].size() || evaluation_points[k].size() == 1);
-                        batch_size += proof.z[k].size();
-                    }
-                    evals_map.resize(batch_size);
-
-                    std::size_t ind = 0;
-                    bool found = false;
-                    for (std::size_t k = 0; k < LPC::basic_fri::batches_num; k++) {
-                        if (evaluation_points[k].size() == 1) {
-                            bool found = false;
-                            std::size_t eval_ind;
-
-                            for (std::size_t j = 0; j < unique_eval_points.size(); j++) {
-                                if (unique_eval_points[j] == evaluation_points[k][0]) {
-                                    found = true;
-                                    eval_ind = j;
-                                    break;
-                                }
-                            }
-                            if (!found) {
-                                unique_eval_points.push_back(evaluation_points[k][0]);
-                                eval_ind = unique_eval_points.size() - 1;
-                            }
-                            for (std::size_t i = 0; i < proof.z[k].size(); i++) {
-                                BOOST_ASSERT(proof.z[k][i].size() == unique_eval_points[eval_ind].size());
-                                evals_map[ind] = eval_ind;
-                                ind++;
-                            }
-                        } else {
-                            for (std::size_t i = 0; i < proof.z[k].size(); i++) {
-                                bool found = false;
-                                BOOST_ASSERT(proof.z[k][i].size() == evaluation_points[k][i].size());
-                                for (std::size_t j = 0; j < unique_eval_points.size(); j++) {
-                                    if (unique_eval_points[j] == evaluation_points[k][i]) {
-                                        evals_map[ind] = j;
-                                        found = true;
-                                        break;
-                                    }
-                                }
-                                if (!found) {
-                                    unique_eval_points.push_back(evaluation_points[k][i]);
-                                    evals_map[ind] = unique_eval_points.size() - 1;
-                                }
-                                ind++;
-                            }
-                        }
-                    }
-                    
-                    combined_U.resize(unique_eval_points.size());
-                    denominators.resize(unique_eval_points.size());
-                    for (std::size_t point_index = 0; point_index < unique_eval_points.size(); point_index++) {
-                        combined_U[point_index] = {0};
-                        denominators[point_index] = {1};
-                        std::vector<
-                                std::pair<typename LPC::field_type::value_type, typename LPC::field_type::value_type>
-                        > U_interpolation_points;
-
-                        U_interpolation_points.resize(unique_eval_points[point_index].size());
-                        for (std::size_t xi_index = 0; xi_index < unique_eval_points[point_index].size(); xi_index++) {
-                            denominators[point_index] =
-                                    denominators[point_index] *
-                                    math::polynomial<typename LPC::field_type::value_type>(
-                                            {-unique_eval_points[point_index][xi_index], 1});
-                        }
-
-                        std::size_t ind = 0;
-                        for (std::size_t k = 0; k < LPC::basic_fri::batches_num; k++) {
-                            for (std::size_t i = 0; i < proof.z[k].size(); i++) {
-                                combined_U[point_index] = combined_U[point_index] * theta;
-                                if(evals_map[ind] == point_index){
-                                    combined_U[point_index] = combined_U[point_index] + get_U();
-                                }
-                                ind++;
-                            }
-                        }
-                    }
-
-                    return verify_eval<typename LPC::basic_fri>(proof.fri_proof, fri_params, commitments, theta,
-                                                                evals_map, combined_U, denominators, transcript);
-                }
-*/
-            }    // namespace algorithms
         }        // namespace zk
     }            // namespace crypto3
 }    // namespace nil


### PR DESCRIPTION
In LPC proof instead of dividing by V, divide by smaller polynomials 1 by 1, it's faster that way. Also removed large commented code.