### PR TITLE
Fix template typing after refactoring

### DIFF
--- a/include/nil/crypto3/zk/snark/systems/plonk/placeholder/params.hpp
+++ b/include/nil/crypto3/zk/snark/systems/plonk/placeholder/params.hpp
@@ -43,7 +43,7 @@ namespace nil {
                     using field_type = FieldType;
                     using value_type = typename field_type::value_type;
                     using public_input_type = std::vector<std::vector<value_type>>;
-                    using constraint_system_type = plonk_constraint_system<value_type>;
+                    using constraint_system_type = plonk_constraint_system<field_type>;
                     using assignment_table_type = plonk_table<field_type, plonk_column<field_type>>;
                 };
 


### PR DESCRIPTION
Was broken [here](https://github.com/NilFoundation/crypto3-zk/commit/957f75cf0d16244659bfbb65a0e342be4154e83a#diff-3177544afbd95c967c493f88cd9148d847d323db1b00f27316f8f7f9d724ced7R46)